### PR TITLE
Add CSV processor with reverse geocoding

### DIFF
--- a/process_csv.py
+++ b/process_csv.py
@@ -1,51 +1,100 @@
+"""Process a CSV of coordinates and print request templates.
+
+The script expects a CSV file containing ``latitude`` and ``longitude`` columns
+(case-insensitive, supporting capital ``L`` prefixes) as well as a column made
+of 9‑digit strings representing SAP IDs.  It renames that column to ``SapID``
+(prompting the user when multiple candidates exist), reverse geocodes each
+coordinate using the Google Maps API and prints a filled request template for
+every row.
+"""
+
+from __future__ import annotations
+
 import os
-from io import StringIO
+import re
+from typing import List
+
 import pandas as pd
 import requests
 
-TEMPLATE = '''\
+TEMPLATE = """\
 Requestor Name: Obii weeks
 Requestor LanID: OXWC
 Requestor Phone number: 3052196892
-Description of Access Issue: need code/contact info 
+Description of Access Issue: need code/contact info
 SAP Equipment ID:{SapID}
 Address Attempted:{Address}
 Description of work: Drone inspection
-'''
+"""
 
-def read_csv_input():
-    """Read CSV content from user input or file path.
 
-    The user can supply either the path to a CSV file or paste the CSV
-    content directly. The function detects whether the provided string is a
-    path to an existing file and reads accordingly.
+def read_csv_file() -> pd.DataFrame:
+    """Return a DataFrame from a user supplied CSV file path.
+
+    The path is cleaned for leading/trailing quotes so that files can be
+    drag‑and‑dropped into the terminal without issues.
     """
-    user_input = input("Enter CSV data or path to CSV file: ")
-    if os.path.exists(user_input):
-        return pd.read_csv(user_input)
-    return pd.read_csv(StringIO(user_input))
+
+    path = input("Enter path to CSV file: ").strip().strip("'").strip('"')
+    return pd.read_csv(path)
 
 
-def clean_dataframe(df: pd.DataFrame) -> pd.DataFrame:
-    """Keep latitude, longitude and SapID columns with proper naming."""
-    mapping = {"Name": "SapID", "asset_num": "SapID", "asset_num_2": "SapID"}
-    df = df.rename(columns=mapping)
-    required = ["latitude", "longitude", "SapID"]
-    df = df[[col for col in required if col in df.columns]]
-    missing = set(required) - set(df.columns)
+def _is_nine_digit_column(series: pd.Series) -> bool:
+    """Return True if all non‑NA values are 9‑digit strings."""
+
+    pattern = re.compile(r"^\d{9}$")
+    values = series.dropna().astype(str)
+    return not values.empty and values.apply(lambda x: bool(pattern.fullmatch(x))).all()
+
+
+def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Identify the SAP ID column and ensure required fields are present."""
+    # Normalize latitude/longitude column names in case they start with
+    # capital ``L`` characters.
+    rename_map = {
+        col: col.lower() for col in df.columns if col.lower() in {"latitude", "longitude"}
+    }
+    if rename_map:
+        df = df.rename(columns=rename_map)
+
+    # Drop the ``Name`` column if it does not contain 9 digit strings.
+    if "Name" in df.columns and not _is_nine_digit_column(df["Name"]):
+        df = df.drop(columns=["Name"])
+
+    candidates: List[str] = [
+        col for col in df.columns if _is_nine_digit_column(df[col])
+    ]
+    if not candidates:
+        raise ValueError("No column with 9-digit strings found.")
+
+    if len(candidates) == 1:
+        sap_col = candidates[0]
+    else:
+        print("Multiple columns with 9-digit strings detected:")
+        for idx, col in enumerate(candidates, 1):
+            print(f"{idx}. {col}")
+        while True:
+            choice = input("Select the column number to use as SapID: ")
+            if choice.isdigit() and 1 <= int(choice) <= len(candidates):
+                sap_col = candidates[int(choice) - 1]
+                break
+            print("Invalid selection. Please try again.")
+
+    df = df.rename(columns={sap_col: "SapID"})
+
+    required = ["SapID", "latitude", "longitude"]
+    missing = [col for col in required if col not in df.columns]
     if missing:
-        raise ValueError(f"Missing required columns: {missing}")
-    return df
+        raise ValueError(f"Missing required columns: {', '.join(missing)}")
+    return df[required]
 
 
 def reverse_geocode(df: pd.DataFrame, api_key: str) -> pd.DataFrame:
     """Reverse geocode latitude/longitude to addresses using Google API."""
+
     addresses = []
     for _, row in df.iterrows():
-        params = {
-            "latlng": f"{row['latitude']},{row['longitude']}",
-            "key": api_key,
-        }
+        params = {"latlng": f"{row['latitude']},{row['longitude']}", "key": api_key}
         try:
             resp = requests.get(
                 "https://maps.googleapis.com/maps/api/geocode/json",
@@ -59,12 +108,15 @@ def reverse_geocode(df: pd.DataFrame, api_key: str) -> pd.DataFrame:
         except requests.RequestException:
             address = ""
         addresses.append(address)
-    return pd.DataFrame({"SapID": df["SapID"], "Address": addresses})
+
+    df = df.copy()
+    df["Address"] = addresses
+    return df[["SapID", "Address", "latitude", "longitude"]]
 
 
-def main():
-    df_input = read_csv_input()
-    df_clean = clean_dataframe(df_input)
+def main() -> None:
+    df_input = read_csv_file()
+    df_clean = prepare_dataframe(df_input)
     api_key = os.getenv("GOOGLE_MAPS_API_KEY") or input("Enter Google Maps API key: ")
     df_final = reverse_geocode(df_clean, api_key)
     for _, row in df_final.iterrows():


### PR DESCRIPTION
## Summary
- handle drag-and-drop CSV input with quote trimming
- detect and rename 9-digit SAP ID columns, prompting user when ambiguous
- normalize latitude/longitude column names to support capital-L prefixes and verify required fields
- reverse geocode coordinates and print request templates

## Testing
- `python -m py_compile process_csv.py`
- `printf 'sample.csv\nFAKE_KEY\n' | python process_csv.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_689d076f5c38832290a15f0b1a124088