### PR TITLE
Handle capitalized latitude/longitude columns

### DIFF
--- a/process_csv.py
+++ b/process_csv.py
@@ -1,7 +1,9 @@
 """Process a CSV of coordinates and print request templates.
 
 The script expects a CSV file containing ``latitude`` and ``longitude`` columns
-as well as a column made of 9‑digit strings representing SAP IDs.  It renames
+as well as a column made of 9‑digit strings representing SAP IDs.  Column names
+for latitude and longitude are matched case-insensitively so that ``Latitude``
+and ``Longitude`` are also accepted.  The script renames
 that column to ``SapID`` (prompting the user when multiple candidates exist),
 reverse geocodes each coordinate using the Google Maps API and prints a filled
 request template for every row.
@@ -48,6 +50,14 @@ def _is_nine_digit_column(series: pd.Series) -> bool:
 
 def prepare_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """Identify the SAP ID column and ensure required fields are present."""
+    # Normalize latitude/longitude column names for possible capitalized forms.
+    rename_map = {}
+    for col in df.columns:
+        lower = col.lower()
+        if lower in {"latitude", "longitude"}:
+            rename_map[col] = lower
+    if rename_map:
+        df = df.rename(columns=rename_map)
 
     # Drop the ``Name`` column if it does not contain 9 digit strings.
     if "Name" in df.columns and not _is_nine_digit_column(df["Name"]):


### PR DESCRIPTION
## Summary
- Document that latitude and longitude column names are matched case-insensitively
- Normalize column names so `Latitude`/`Longitude` are handled

## Testing
- `python -m py_compile process_csv.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_689d0be70ebc83229008bfd5c8789ae3